### PR TITLE
Enable GitHub Actions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,26 @@
+name: github pages
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup mdBook
+        uses: peaceiris/actions-mdbook@v1
+        with:
+          mdbook-version: '0.4.1'
+          # mdbook-version: 'latest'
+
+      - run: mdbook build
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./book

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,7 +15,6 @@ jobs:
         uses: peaceiris/actions-mdbook@v1
         with:
           mdbook-version: '0.4.1'
-          # mdbook-version: 'latest'
 
       - run: mdbook build
 


### PR DESCRIPTION
solve #2 

It is important to note that even if this pull request is accepted, `gh-pages` branch won't be automatically deployed  immediately:

* [mdBook Action](https://github.com/marketplace/actions/mdbook-action#%EF%B8%8F-create-your-workflow)
* [GitHub Actions for GitHub Pages](https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-first-deployment-with-github_token)

After setting up the branch as described in the above two links, GitHub Actions will be automatically linked from the next commit.