### PR TITLE
使用するmdbookのバージョンを0.4.6にあげます

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
         with:
-          mdbook-version: '0.4.1'
+          mdbook-version: '0.4.6'
 
       - run: mdbook build
 


### PR DESCRIPTION
ref: [mdBook security advisory
](https://blog.rust-lang.org/2021/01/04/mdbook-security-advisory.html)